### PR TITLE
:memo: docs: 同步文档中的依赖版本信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CodeAS Backend - CodeAS 后端项目
 
 [![Java](https://img.shields.io/badge/Java-21-orange.svg)](https://openjdk.java.net/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.2.1-brightgreen.svg)](https://spring.io/projects/spring-boot)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.0-brightgreen.svg)](https://spring.io/projects/spring-boot)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15-blue.svg)](https://www.postgresql.org/)
 [![Redis](https://img.shields.io/badge/Redis-7-red.svg)](https://redis.io/)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -47,14 +47,15 @@ CodeAS Backend 是 akko.space 网站的后端服务项目，基于 Spring Boot 3
 | 技术 | 版本     | 说明 |
 |------|--------|------|
 | Java | 21     | 编程语言 |
-| Spring Boot | 3.2.1  | 应用框架 |
+| Spring Boot | 3.5.0  | 应用框架 |
 | PostgreSQL | 15+    | 主数据库 |
 | Redis | 7+     | 缓存数据库 |
-| MyBatis Plus | 3.5.5  | ORM框架 |
-| Flyway | 11.8.2 | 数据库迁移 |
+| MyBatis Plus | 3.5.12 | ORM框架 |
+| Flyway | 11.9.0 | 数据库迁移 |
 | Caffeine | 3.1.8  | 本地缓存 |
-| JWT | 0.12.3 | 认证令牌 |
-| SpringDoc | 2.3.0  | API文档 |
+| JWT | 0.12.6 | 认证令牌 |
+| SpringDoc | 2.8.8  | API文档 |
+| Dotenv Java | 3.2.0  | 环境变量管理 |
 | Docker | -      | 容器化 |
 
 ## 快速开始

--- a/docs/project/ARCHITECTURE.md
+++ b/docs/project/ARCHITECTURE.md
@@ -341,20 +341,21 @@
 
 | 层级 | 技术 | 版本 | 说明 |
 |------|------|------|------|
-| 应用框架 | Spring Boot | 3.2.1 | 主框架 |
+| 应用框架 | Spring Boot | 3.5.0 | 主框架 |
 | 编程语言 | Java | 21 | LTS版本 |
 | 数据库 | PostgreSQL | 15-alpine | 主数据库 |
 | 缓存 | Redis | 7-alpine | 分布式缓存 |
 | 本地缓存 | Caffeine | 3.1.8 | 高性能本地缓存 |
-| ORM框架 | MyBatis Plus | 3.5.5 | 数据访问层 |
-| 数据库迁移 | Flyway | 11.8.3 | 版本控制 |
+| ORM框架 | MyBatis Plus | 3.5.12 | 数据访问层 |
+| 数据库迁移 | Flyway | 11.9.0 | 版本控制 |
 | 安全框架 | Spring Security | 6.x | 安全认证 |
-| JWT | JJWT | 0.12.3 | 令牌处理 |
-| API文档 | SpringDoc | 2.3.0 | OpenAPI 3.0 |
+| JWT | JJWT | 0.12.6 | 令牌处理 |
+| API文档 | SpringDoc | 2.8.8 | OpenAPI 3.0 |
 | 工具库 | Hutool | 5.8.38 | 工具集合 |
-| 工具库 | Commons Lang3 | 3.14.0 | 工具集合 |
-| 数据库驱动 | PostgreSQL Driver | 42.7.1 | 数据库连接 |
-| 代码简化 | Lombok | - | 注解处理器 |
+| 工具库 | Commons Lang3 | 3.17.0 | 工具集合 |
+| 数据库驱动 | PostgreSQL Driver | 42.7.2 | 数据库连接 |
+| 环境变量管理 | Dotenv Java | 3.2.0 | 配置管理 |
+| 代码简化 | Lombok | 1.18.30 | 注解处理器 |
 | 构建工具 | Maven | 3.8+ | 项目管理 |
 | 容器化 | Docker | 20+ | 容器部署 |
 

--- a/docs/project/CHANGELOG.md
+++ b/docs/project/CHANGELOG.md
@@ -13,9 +13,24 @@
 ### 变更
 - 📚 移除手动维护的API文档，改为使用Swagger自动生成
 - 📚 优化文档结构，强调在线API文档的重要性
+- :arrow_up: 升级 Spring Boot 从 3.2.1 到 3.5.0
+- :arrow_up: 升级 PostgreSQL Driver 从 42.7.1 到 42.7.2
+- :arrow_up: 升级 MyBatis Plus 从 3.5.5 到 3.5.12
+- :arrow_up: 升级 Flyway 从 11.8.3 到 11.9.0
+- :arrow_up: 升级 JWT (JJWT) 从 0.12.3 到 0.12.6
+- :arrow_up: 升级 SpringDoc OpenAPI 从 2.3.0 到 2.8.8
+- :arrow_up: 升级 Commons Lang3 从 3.14.0 到 3.17.0
+- :arrow_up: 升级 Dotenv Java 从 3.0.0 到 3.2.0
+- :arrow_up: 升级 JaCoCo 从 0.8.11 到 0.8.13
+- :arrow_up: 升级 License Maven Plugin 从 4.3 到 5.0.0
+- :arrow_up: 升级 Maven Assembly Plugin 从 3.6.0 到 3.7.1
+- :arrow_up: 升级 SonarQube Scanner 从 3.10.0.2594 到 5.1.0.4751
 
 ### 修复
-- 无
+- :bug: 修复 PostgreSQL Driver CVE-2024-1597 安全漏洞
+- :bug: 修复 MyBatis Plus 分页查询相关问题
+- :bug: 修复 JWT 令牌处理的多个问题
+- :bug: 修复 SpringDoc OpenAPI Schema 生成问题
 
 ### 移除
 - 📚 删除 `docs/api/` 目录及手动维护的API文档
@@ -41,17 +56,18 @@
 
 ### 技术栈
 - Java 21
-- Spring Boot 3.2.1
+- Spring Boot 3.5.0
 - PostgreSQL 15-alpine
-- MyBatis Plus 3.5.5
-- Flyway 11.8.3
+- MyBatis Plus 3.5.12
+- Flyway 11.9.0
 - Redis 7-alpine
 - Caffeine 3.1.8
 - Spring Security
-- JWT (JJWT 0.12.3)
-- SpringDoc OpenAPI 2.3.0
+- JWT (JJWT 0.12.6)
+- SpringDoc OpenAPI 2.8.8
 - Hutool 5.8.38
-- Commons Lang3 3.14.0
-- PostgreSQL Driver 42.7.1
-- Lombok
+- Commons Lang3 3.17.0
+- PostgreSQL Driver 42.7.2
+- Dotenv Java 3.2.0
+- Lombok 1.18.30
 - Maven

--- a/docs/project/PROJECT_SUMMARY.md
+++ b/docs/project/PROJECT_SUMMARY.md
@@ -80,18 +80,19 @@ mvn spring-boot:run
 | 技术 | 版本 | 用途 |
 |------|------|------|
 | Java | 21 | 编程语言 |
-| Spring Boot | 3.2.1 | 应用框架 |
+| Spring Boot | 3.5.0 | 应用框架 |
 | PostgreSQL | 15-alpine | 主数据库 |
 | Redis | 7-alpine | 缓存数据库 |
-| MyBatis Plus | 3.5.5 | ORM框架 |
-| Flyway | 11.8.3 | 数据库迁移 |
+| MyBatis Plus | 3.5.12 | ORM框架 |
+| Flyway | 11.9.0 | 数据库迁移 |
 | Caffeine | 3.1.8 | 本地缓存 |
-| JWT (JJWT) | 0.12.3 | 认证令牌 |
-| SpringDoc | 2.3.0 | API文档 |
-| Lombok | - | 代码简化 |
+| JWT (JJWT) | 0.12.6 | 认证令牌 |
+| SpringDoc | 2.8.8 | API文档 |
+| Lombok | 1.18.30 | 代码简化 |
 | Hutool | 5.8.38 | 工具库 |
-| Commons Lang3 | 3.14.0 | 工具库 |
-| PostgreSQL Driver | 42.7.1 | 数据库驱动 |
+| Commons Lang3 | 3.17.0 | 工具库 |
+| PostgreSQL Driver | 42.7.2 | 数据库驱动 |
+| Dotenv Java | 3.2.0 | 环境变量管理 |
 
 ## 📁 项目结构
 


### PR DESCRIPTION
## 📝 修复文档版本不一致问题

### 🎯 问题描述
在检查已合并的PR时发现，多个依赖升级后文档中的版本信息没有同步更新，导致文档与实际pom.xml中的版本不一致。

### 🔧 修复内容

#### 更新的依赖版本
- **Spring Boot**: `3.2.1` → `3.5.0`
- **PostgreSQL Driver**: `42.7.1` → `42.7.2`
- **MyBatis Plus**: `3.5.5` → `3.5.12`
- **Flyway**: `11.8.3` → `11.9.0`
- **JWT (JJWT)**: `0.12.3` → `0.12.6`
- **SpringDoc OpenAPI**: `2.3.0` → `2.8.8`
- **Commons Lang3**: `3.14.0` → `3.17.0`

#### 新增的版本信息
- **Lombok**: `1.18.30` (之前未记录)
- **Dotenv Java**: `3.2.0` (之前未记录)

### 📋 更新的文档文件
- `README.md` - 主页技术栈表格和徽章
- `docs/project/PROJECT_SUMMARY.md` - 技术栈总览表
- `docs/project/ARCHITECTURE.md` - 核心技术栈表
- `docs/project/CHANGELOG.md` - 更新日志，记录所有依赖升级历史

### 🛡️ 安全修复记录
在CHANGELOG中记录了以下安全修复：
- PostgreSQL Driver CVE-2024-1597 安全漏洞修复
- MyBatis Plus 分页查询相关问题修复
- JWT 令牌处理的多个问题修复
- SpringDoc OpenAPI Schema 生成问题修复

### 🔍 构建工具升级记录
同时记录了以下构建工具的升级：
- JaCoCo: `0.8.11` → `0.8.13`
- License Maven Plugin: `4.3` → `5.0.0`
- Maven Assembly Plugin: `3.6.0` → `3.7.1`
- SonarQube Scanner: `3.10.0.2594` → `5.1.0.4751`

### ✅ 验证
- [x] 所有文档中的版本信息与pom.xml保持一致
- [x] 技术栈表格信息完整准确
- [x] CHANGELOG记录了所有相关变更
- [x] 安全修复得到适当记录

### 📚 相关PR
此次更新涵盖了以下已合并PR的文档同步：
- PR #9: Spring Boot 3.2.1 → 3.5.0
- PR #2: PostgreSQL Driver 42.7.1 → 42.7.2
- PR #8, #17: MyBatis Plus 3.5.5 → 3.5.12
- PR #15, #21: Flyway 11.8.3 → 11.9.0
- PR #13, #22: JWT (JJWT) 0.12.3 → 0.12.6
- 以及其他多个构建工具升级PR

### 🎯 影响范围
- ✅ **无代码变更** - 仅文档更新
- ✅ **无功能影响** - 纯文档同步
- ✅ **提升准确性** - 确保文档与实际版本一致